### PR TITLE
feat: set indexer sns topic from env

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -3,3 +3,5 @@ CLUSTER_IPFS_ADDR="/dns4/peer.ipfs-elastic-provider-aws.com/tcp/3000/ws/p2p/bafz
 
 # Base64 encoded user:pass string
 CLUSTER_BASIC_AUTH_TOKEN="???"
+
+# INDEXER_TOPIC_ARN=""


### PR DESCRIPTION
Allows us to specify the ARN of the existing bucket-to-indexer SNS topic, so we can notify elastic-ipfs when a new CAR is written to s3.


License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>