### PR TITLE
feat: add pickup.dag.haus as custom domain

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -3,3 +3,7 @@ CLUSTER_IPFS_ADDR="/dns4/elastic.dag.house/tcp/443/wss/p2p/bafzbeibhqavlasjc7dvb
 
 # Base64 encoded user:pass string
 CLUSTER_BASIC_AUTH_TOKEN="???"
+
+# uncomment to try out deploying the api under a custom domain.
+# the value should match a hosted zone configured in route53 that your aws account has access to.
+# HOSTED_ZONE=pickup.dag.haus

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -1,4 +1,4 @@
-import { StackContext, Api, Table, Queue, Bucket, ApiDomainProps } from '@serverless-stack/resources'
+import { StackContext, Api, Table, Queue, Bucket } from '@serverless-stack/resources'
 
 export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bucket: Bucket } {
   const queue = new Queue(stack, 'Pin')
@@ -39,7 +39,7 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
 
   stack.addOutputs({
     ApiEndpoint: api.url,
-    CustomDomain: customDomain ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
+    CustomDomain: (customDomain !== undefined) ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
   })
 
   return {
@@ -48,7 +48,7 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
   }
 }
 
-function getCustomDomain (stage: string, hostedZone?: string): ApiDomainProps | undefined {
+function getCustomDomain (stage: string, hostedZone?: string): { domainName: string, hostedZone: string} | undefined {
   if (hostedZone === undefined) {
     return undefined
   }


### PR DESCRIPTION
- Cloudflare DNS has ns records for pickup.dag.haus pointing to aws route53
- Adds config to auto update route53 records on deployment

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>