### PR TITLE
feat: notify e-ipfs indexer on CAR put

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -7,3 +7,7 @@ CLUSTER_BASIC_AUTH_TOKEN="???"
 # uncomment to try out deploying the api under a custom domain.
 # the value should match a hosted zone configured in route53 that your aws account has access to.
 # HOSTED_ZONE=pickup.dag.haus
+
+# E-IPFS Indexer queue
+# SQS_INDEXER_QUEUE_URL
+# SQS_INDEXER_QUEUE_REGION

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -17,10 +17,12 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
       created: {
         events: ['object_created'],
         function: {
-          handler: 'basic/update-pin.handler',
+          handler: 'basic/car-created.handler',
           permissions: [table],
           environment: {
-            TABLE_NAME: table.tableName
+            TABLE_NAME: table.tableName,
+            SQS_INDEXER_QUEUE_URL: process.env.SQS_INDEXER_QUEUE_URL ?? '',
+            SQS_INDEXER_QUEUE_REGION: process.env.SQS_INDEXER_QUEUE_REGION ?? ''
           }
         }
       }


### PR DESCRIPTION
This implementation has pickup send a message directly to the e-ipfs indexer queue.

A subsequent iteration will have pickup create it's own SNS topic for S3 events for E-IPFS to subscribe to per #17

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>