### PR TITLE
feat: publish s3 events to SNS topic

### DIFF
--- a/api/basic/update-pin.js
+++ b/api/basic/update-pin.js
@@ -2,12 +2,25 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 
 /**
+ * Deal with the horror of S3Events wrapped up as strings in SNSEvents.
+ *
+ * @param {import('aws-lambda').SNSEvent} snsEvent
+ */
+export async function snsEventHandler (snsEvent) {
+  for (const record of snsEvent.Records) {
+    /** @type {import('aws-lambda').S3Event} */
+    const s3Event = JSON.parse(record.Sns.Message)
+    await s3EventHandler(s3Event)
+  }
+}
+
+/**
  * Set pin status to pinned when receiving an
  * S3 `object_created` event for a .car file.
  *
  * @param {import('aws-lambda').S3Event} event
  */
-export async function handler (event) {
+export async function s3EventHandler (event) {
   const {
     TABLE_NAME: table = '',
     // set for testing

--- a/api/test/basic.test.js
+++ b/api/test/basic.test.js
@@ -3,7 +3,7 @@ import { SQSClient, CreateQueueCommand, GetQueueUrlCommand, ReceiveMessageComman
 import { GenericContainer as Container } from 'testcontainers'
 import { addPin, putIfNotExists, handler as addPinHandler } from '../basic/add-pin.js'
 import { getPin, handler as getPinHandler } from '../basic/get-pin.js'
-import { handler as updatePin } from '../basic/update-pin.js'
+import { s3EventHandler as updatePin } from '../basic/update-pin.js'
 import { nanoid } from 'nanoid'
 import test from 'ava'
 

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -28,7 +28,11 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
 
   const bucket = new Bucket(stack, 'Car', {
     notifications: {
-      topic: s3Topic
+      topic: {
+        type: 'topic',
+        topic: s3Topic,
+        events: ['object_created']
+      }
     }
   })
 

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -1,4 +1,4 @@
-import { StackContext, Api, Table, Queue, Bucket } from '@serverless-stack/resources'
+import { StackContext, Api, Table, Queue, Bucket, Topic } from '@serverless-stack/resources'
 
 export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bucket: Bucket } {
   const queue = new Queue(stack, 'Pin')
@@ -12,18 +12,23 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
     }
   })
 
-  const bucket = new Bucket(stack, 'Car', {
-    notifications: {
-      created: {
-        events: ['object_created'],
+  const s3Topic = new Topic(stack, 'S3Events', {
+    subscribers: {
+      updatePin: {
         function: {
-          handler: 'basic/update-pin.handler',
+          handler: 'basic/update-pin.snsEventHandler',
           permissions: [table],
           environment: {
             TABLE_NAME: table.tableName
           }
         }
       }
+    }
+  })
+
+  const bucket = new Bucket(stack, 'Car', {
+    notifications: {
+      topic: s3Topic
     }
   })
 
@@ -51,6 +56,7 @@ export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bu
   })
 
   stack.addOutputs({
+    S3EventsTopicARN: s3Topic.topicArn,
     ApiEndpoint: api.url,
     CustomDomain: (customDomain !== undefined) ? `https://${customDomain.domainName}` : 'Set HOSTED_ZONE in env to deploy to a custom domain'
   })


### PR DESCRIPTION
As proposed by E-IPFS team, this PR has pickup notify all s3 events on an SNS Topic.

The Topic ARN is published as an output so we can share it with them, and our s3 notifcation lambda is now an sns event subscriber.

The next step is to configure E-IPFS to listen to the topic, so that CARs written by pickup get indexed and published.

Fixes #17 

Probably supersedes #30 but both solutions are provided so we can pick a path.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>