### PR TITLE
wip: avoid assigning a fixed elastic-ip per deployment

### DIFF
--- a/stacks/PickupStack.ts
+++ b/stacks/PickupStack.ts
@@ -28,7 +28,8 @@ export function PickupStack ({ stack }: StackContext): void {
     // retentionPeriod: Duration.days(1),
     // visibilityTimeout: Duration.minutes(5),
     // for debug!
-    enableExecuteCommand: true
+    enableExecuteCommand: true,
+    assignPublicIp: true
   })
 
   // go-ipfs as sidecar!


### PR DESCRIPTION
looking for a fix for the "The maximum number of addresses has been reached" error.

we don't need fixed elastic-ips for this.

see: https://github.com/web3-storage/pickup/issues/32

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>