### PR TITLE
feat: abort requests after timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "ts-node": "^10.8.2",
         "ts-standard": "^11.0.0",
         "typescript": "^4.7.2"
+      },
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "api": {
@@ -5569,6 +5572,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
+    },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
@@ -9513,8 +9521,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.6",
-      "license": "MIT",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -13052,9 +13061,10 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.95.0",
         "@aws-sdk/lib-storage": "^3.97.0",
+        "debounce": "^1.2.1",
         "multiaddr": "^10.0.1",
         "multiformats": "^9.6.5",
-        "node-fetch": "^3.2.4",
+        "node-fetch": "^3.2.10",
         "p-retry": "^5.1.1",
         "sqs-consumer": "^5.7.0"
       },
@@ -13067,7 +13077,7 @@
         "testcontainers": "^8.10.1"
       },
       "engines": {
-        "node": "16.x"
+        "node": ">=16.14"
       }
     }
   },
@@ -17036,6 +17046,11 @@
         "time-zone": "^1.0.0"
       }
     },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
+    },
     "debounce-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
@@ -19592,7 +19607,9 @@
       "version": "1.0.0"
     },
     "node-fetch": {
-      "version": "3.2.6",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -19919,10 +19936,11 @@
         "@aws-sdk/lib-storage": "^3.97.0",
         "@web-std/blob": "^3.0.4",
         "ava": "^4.3.0",
+        "debounce": "^1.2.1",
         "ipfs-car": "^0.7.0",
         "multiaddr": "^10.0.1",
         "multiformats": "^9.6.5",
-        "node-fetch": "^3.2.4",
+        "node-fetch": "^3.2.10",
         "p-retry": "^5.1.1",
         "sqs-consumer": "^5.7.0",
         "standard": "^16.0.4",

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "nodeArguments": [
       "--loader=ts-node/esm"
     ]
+  },
+  "engines": {
+    "node": ">=16.14"
   }
 }

--- a/pickup/lib/consumer.js
+++ b/pickup/lib/consumer.js
@@ -10,6 +10,8 @@ export async function createConsumer ({ ipfsApiUrl, queueUrl, s3 }) {
 
   const app = Consumer.create({
     queueUrl,
+    // needs partial acks before we can increase batch size
+    // see: https://github.com/bbc/sqs-consumer/pull/255
     batchSize: 1, // 1 to 10
     visibilityTimeout: 20, // seconds, how long to hide message from queue after reading.
     heartbeatInterval: 10, // seconds, must be lower than `visibilityTimeout`. how long before increasing the `visibilityTimeout`
@@ -19,9 +21,7 @@ export async function createConsumer ({ ipfsApiUrl, queueUrl, s3 }) {
     // see: https://www.speedtest.net/global-index
     // see: https://www.omnicalculator.com/other/download-time?c=GBP&v=fileSize:32!gigabyte,downloadSpeed:5!megabit
     // TODO: enforce 32GiB limit
-    // TODO: monitor throughput and bail early if stalled.
-    // handleMessageTimeout: 4 * 60 * 60 * 1000, // ms, error if processing takes longer than this.
-    handleMessageTimeout: 10 * 1000, // ms, error if processing takes longer than this.
+    handleMessageTimeout: 4 * 60 * 60 * 1000, // ms, error if processing takes longer than this.
     handleMessageBatch: async (messages) => {
       return pickupBatch(messages, { ipfsApiUrl, createS3Uploader, s3 })
     }

--- a/pickup/lib/ipfs.js
+++ b/pickup/lib/ipfs.js
@@ -1,42 +1,56 @@
+import { compose } from 'node:stream'
 import { CID } from 'multiformats/cid'
 import { Multiaddr } from 'multiaddr'
+import debounce from 'debounce'
 import fetch from 'node-fetch'
 
-export async function fetchCar (cid, ipfsApiUrl) {
+export async function fetchCar (cid, ipfsApiUrl, timeoutMs = 30000) {
   if (!isCID(cid)) {
     throw new Error({ message: `Invalid CID: ${cid}` })
   }
   const url = new URL(`/api/v0/dag/export?arg=${cid}`, ipfsApiUrl)
-  const res = await fetch(url, { method: 'POST' })
+  const ctl = new AbortController()
+  const startCountdown = debounce(() => ctl.abort(), timeoutMs)
+  startCountdown()
+  const res = await fetch(url, { method: 'POST', signal: ctl.signal })
   if (!res.ok) {
     throw new Error(`${res.status} ${res.statusText} ${url}`)
   }
-  return res.body
+  async function* restartCountdown (source) {
+    for await (const chunk of source) {
+      startCountdown()
+      yield chunk
+    }
+  }
+  return compose(res.body, restartCountdown)
 }
 
-export async function connectTo (origins = [], ipfsApiUrl) {
+export async function connectTo (origins = [], ipfsApiUrl, timeoutMs = 10000) {
   for (const addr of origins.filter(isMultiaddr)) {
     const url = new URL(`/api/v0/swarm/connect?arg=${addr}`, ipfsApiUrl)
-    const res = await fetch(url, { method: 'POST' })
+    const signal = AbortSignal.timeout(timeoutMs)
+    const res = await fetch(url, { method: 'POST', signal })
     if (!res.ok) {
       console.log(`Error connecting to ${addr} - got: ${res.status} ${res.statusText}`)
     }
   }
 }
 
-export async function disconnect (origins = [], ipfsApiUrl) {
+export async function disconnect (origins = [], ipfsApiUrl, timeoutMs = 10000) {
   for (const addr of origins.filter(isMultiaddr)) {
     const url = new URL(`/api/v0/swarm/disconnect?arg=${addr}`, ipfsApiUrl)
-    const res = await fetch(url, { method: 'POST' })
+    const signal = AbortSignal.timeout(timeoutMs)
+    const res = await fetch(url, { method: 'POST', signal })
     if (!res.ok) {
       console.log(`Error disconnecting from ${addr} - got: ${res.status} ${res.statusText}`)
     }
   }
 }
 
-export async function waitForGC (ipfsApiUrl) {
+export async function waitForGC (ipfsApiUrl, timeoutMs = 60000) {
   const url = new URL('/api/v0/repo/gc?silent=true', ipfsApiUrl)
-  const res = await fetch(url, { method: 'POST' })
+  const signal = AbortSignal.timeout(timeoutMs)
+  const res = await fetch(url, { method: 'POST', signal })
   if (!res.ok) {
     console.log(`Error GCing - got: ${res.status} ${res.statusText}`)
   }
@@ -57,10 +71,11 @@ export function isCID (str) {
   return Boolean(CID.parse(str))
 }
 
-export async function testIpfsApi (ipfsApiUrl) {
+export async function testIpfsApi (ipfsApiUrl, timeoutMs = 10000) {
   const url = new URL('/api/v0/id', ipfsApiUrl)
+  const signal = AbortSignal.timeout(timeoutMs)
   try {
-    const res = await fetch(url, { method: 'POST' })
+    const res = await fetch(url, { method: 'POST', signal })
     if (!res.ok) {
       if (res.status === 404) {
         throw new Error('IPFS API returned 404. IPFS_API_URL must be the RPC API port (:5001) rather than the ipfsApiUrl port (:8080)')

--- a/pickup/lib/ipfs.js
+++ b/pickup/lib/ipfs.js
@@ -16,7 +16,7 @@ export async function fetchCar (cid, ipfsApiUrl, timeoutMs = 30000) {
   if (!res.ok) {
     throw new Error(`${res.status} ${res.statusText} ${url}`)
   }
-  async function* restartCountdown (source) {
+  async function * restartCountdown (source) {
     for await (const chunk of source) {
       startCountdown()
       yield chunk

--- a/pickup/package.json
+++ b/pickup/package.json
@@ -15,9 +15,10 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.95.0",
     "@aws-sdk/lib-storage": "^3.97.0",
+    "debounce": "^1.2.1",
     "multiaddr": "^10.0.1",
     "multiformats": "^9.6.5",
-    "node-fetch": "^3.2.4",
+    "node-fetch": "^3.2.10",
     "p-retry": "^5.1.1",
     "sqs-consumer": "^5.7.0"
   },
@@ -30,6 +31,6 @@
     "testcontainers": "^8.10.1"
   },
   "engines": {
-    "node": "16.x"
+    "node": ">=16.14"
   }
 }

--- a/pickup/test/pickup.test.js
+++ b/pickup/test/pickup.test.js
@@ -109,6 +109,24 @@ test('pickupBatch', async t => {
   }
 })
 
+test('pickupBatch timeout', async t => {
+  const rareCid = 'bafkreifd77jsx5jwez7nthztzc6smqmvgrj43ip6scqccnxoeqizc3qn3i' // "olizilla Tue  8 Nov 2022 15:31:39 GMT"
+  const { s3, createBucket, ipfsApiUrl } = t.context
+  const bucket = await createBucket()
+  const cids = [rareCid]
+  const msgs = cids.map((cid, i) => ({
+    Body: JSON.stringify({
+      cid,
+      bucket,
+      key: `batch/${cid}.car`,
+      requestid: `#${i}`
+    })
+  }))
+
+  const res = await pickupBatch(msgs, { createS3Uploader, s3, ipfsApiUrl })
+  t.is(res.length, 0, 'Expecting 0 succesful jobs. The CID should not be fetchable')
+})
+
 async function resToFiles (res) {
   const files = []
   for await (const file of unpackStream(res.Body)) {


### PR DESCRIPTION
- Adds a `timeoutMs` param to all ipfs requests.
- fetchCar may take a long time, so the timeout is treated as a rolling window. We restart the countdown when a chunk of data comes in.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>