### PR TITLE
fix: dont bind secret when env is already set

### DIFF
--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -1,7 +1,7 @@
 import { StackContext, Api, Table, Queue, Bucket, Topic, Config } from '@serverless-stack/resources'
 import { SSTConstruct } from '@serverless-stack/resources/dist/Construct'
 
-export function BasicApiStack({ app, stack }: StackContext): { queue: Queue, bucket: Bucket } {
+export function BasicApiStack ({ app, stack }: StackContext): { queue: Queue, bucket: Bucket } {
   const queue = new Queue(stack, 'Pin')
 
   const table = new Table(stack, 'BasicV2', {

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -46,7 +46,7 @@ export function BasicApiStack({ app, stack }: StackContext): { queue: Queue, buc
     CLUSTER_IPFS_ADDR: process.env.CLUSTER_IPFS_ADDR ?? ''
   }
   const AUTH_TOKEN = new Config.Secret(stack, 'AUTH_TOKEN')
-  configureAuth(apiFunctionBindList, AUTH_TOKEN, apiFunctionEnvironment)
+  configureAuth(apiFunctionBindList, apiFunctionEnvironment, AUTH_TOKEN)
 
   const api = new Api(stack, 'api', {
     customDomain,
@@ -76,7 +76,7 @@ export function BasicApiStack({ app, stack }: StackContext): { queue: Queue, buc
   }
 }
 
-function configureAuth (apiFunctionBindList: SSTConstruct[], AUTH_TOKEN: Config.Secret, apiFunctionEnvironment: Record<string, string>): void {
+function configureAuth (apiFunctionBindList: SSTConstruct[], apiFunctionEnvironment: Record<string, string>, AUTH_TOKEN: Config.Secret): void {
   if (process.env.CLUSTER_BASIC_AUTH_TOKEN == null) {
     apiFunctionBindList.push(AUTH_TOKEN)
   } else {


### PR DESCRIPTION
Stack needs to have a condition to decide if the lambda should bind with the secret or not. When it's bonded, it tries to fetch it during startup.