### PR TITLE
Enable Container Insights

### DIFF
--- a/stacks/PickupStack.ts
+++ b/stacks/PickupStack.ts
@@ -1,11 +1,15 @@
 import { StackContext, use, Queue, Bucket } from '@serverless-stack/resources'
 import { BasicApiStack } from './BasicApiStack'
-import { ContainerImage } from 'aws-cdk-lib/aws-ecs'
+import { Cluster, ContainerImage } from 'aws-cdk-lib/aws-ecs'
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets'
 import { QueueProcessingFargateService } from './lib/queue-processing-fargate-service'
 
 export function PickupStack ({ stack }: StackContext): void {
   const basicApi = use(BasicApiStack) as unknown as { queue: Queue, bucket: Bucket }
+
+  const cluster = new Cluster(stack, 'ipfs', {
+    containerInsights: true
+  })
 
   // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns-readme.html#queue-processing-services
   const service = new QueueProcessingFargateService(stack, 'Service', {
@@ -28,7 +32,8 @@ export function PickupStack ({ stack }: StackContext): void {
     // retentionPeriod: Duration.days(1),
     // visibilityTimeout: Duration.minutes(5),
     // for debug!
-    enableExecuteCommand: true
+    enableExecuteCommand: true,
+    cluster
   })
 
   // go-ipfs as sidecar!


### PR DESCRIPTION
ContainerInsights allow us to get count metrics about tasks (Ex: `RunningTaskCount`).

:warning: Note that this will recreate the existing cluster, as I'm no longer using the "default".
```
[~] Cluster (requires replacement)
 │   └─ [~] .Ref:
 │       ├─ [-] EcsDefaultClusterMnL3mNNYN926A5246
 │       └─ [+] ipfs117ACE71
```