### PR TITLE
Feat/failed pin

### DIFF
--- a/api/basic/add-pin.ts
+++ b/api/basic/add-pin.ts
@@ -101,7 +101,7 @@ export async function handler (event: APIGatewayProxyEventV2, context: Context):
  * with optional source multiaddrs specified as origins list.
  */
 export async function addPin ({ cid, origins, bucket, sqs, queueUrl, dynamo, table }: AddPinInput): Promise<ClusterAddResponseBody> {
-  const { shouldQueue, pin } = await putIfNotExists({ cid, dynamo, table })
+  const { shouldQueue, pin } = await upsertOnDynamo({ cid, dynamo, table })
   if (shouldQueue) {
     await addToQueue({ cid, origins, bucket, sqs, queueUrl })
   }
@@ -111,7 +111,7 @@ export async function addPin ({ cid, origins, bucket, sqs, queueUrl, dynamo, tab
 /**
  * Save Pin to Dynamo. If we already have that CID then return the existing.
  */
-export async function putIfNotExists ({ cid, dynamo, table }: UpsertPinInput): Promise<{shouldQueue: boolean, pin: Pin}> {
+export async function upsertOnDynamo ({ cid, dynamo, table }: UpsertPinInput): Promise<{shouldQueue: boolean, pin: Pin}> {
   const client = DynamoDBDocumentClient.from(dynamo)
   const pin: Pin = {
     cid,

--- a/api/basic/add-pin.ts
+++ b/api/basic/add-pin.ts
@@ -1,5 +1,5 @@
 import { DynamoDBClient, ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
 import { APIGatewayProxyEventV2, Context } from 'aws-lambda'
 import { ClusterAddResponseBody, ErrorCode, Pin, Response, ValidationError } from './schema.js'
@@ -135,11 +135,54 @@ export async function putIfNotExists ({ cid, dynamo, table }: UpsertPinInput): P
         Key: { cid }
       }))
       logger.info({ code: 'DYNAMO_GET' }, 'Get existing pin')
-      return { shouldQueue: true, pin: existing.Item as Pin }
+
+      const foundPin = existing.Item as Pin
+      let newPin
+      if (foundPin.status === 'failed') {
+        newPin = await updateFailedItem({ cid, dynamo, table })
+        return { shouldQueue: true, pin: newPin }
+      }
+
+      return { shouldQueue: false, pin: existing.Item as Pin }
     }
     logger.error({ err }, 'Dynamo error')
   }
   throw new ErrorCode('DYNAMO_SAVE_PIN', 'Failed to save Pin. Please try again')
+}
+
+/**
+ * Save Pin to Dynamo. If we already have that CID then return the existing.
+ */
+export async function updateFailedItem ({ cid, dynamo, table }: UpsertPinInput): Promise<Pin> {
+  const pin: Pin = {
+    cid,
+    status: 'queued',
+    created: new Date().toISOString()
+  }
+  try {
+    const client = DynamoDBDocumentClient.from(dynamo)
+    await client.send(new UpdateCommand({
+      TableName: table,
+      Key: { cid },
+      ExpressionAttributeNames: {
+        '#status': 'status',
+        '#created': 'created'
+      },
+      ExpressionAttributeValues: {
+        ':s': 'queued',
+        ':c': pin.created,
+        ':expectedStatus': 'failed'
+      },
+      UpdateExpression: 'set #status = :s, #created = :c',
+      ConditionExpression: '#status = :expectedStatus',
+      ReturnValues: 'ALL_NEW'
+    }))
+
+    return pin
+  } catch (err) {
+    logger.error({ err }, 'Dynamo update failed status')
+    throw err
+  }
 }
 
 /**

--- a/api/basic/add-pin.ts
+++ b/api/basic/add-pin.ts
@@ -101,8 +101,10 @@ export async function handler (event: APIGatewayProxyEventV2, context: Context):
  * with optional source multiaddrs specified as origins list.
  */
 export async function addPin ({ cid, origins, bucket, sqs, queueUrl, dynamo, table }: AddPinInput): Promise<ClusterAddResponseBody> {
-  const { pin } = await putIfNotExists({ cid, dynamo, table })
-  await addToQueue({ cid, origins, bucket, sqs, queueUrl })
+  const { shouldQueue, pin } = await putIfNotExists({ cid, dynamo, table })
+  if (shouldQueue) {
+    await addToQueue({ cid, origins, bucket, sqs, queueUrl })
+  }
   return toAddPinResponse(pin, origins)
 }
 

--- a/api/test/add-pin.test.js
+++ b/api/test/add-pin.test.js
@@ -53,23 +53,112 @@ test.before(async t => {
   }
 })
 
-test('addPin', async t => {
+test('addPin for the first time', async t => {
   const { dynamo, table, sqs, createQueue } = t.context
   const queueUrl = await createQueue()
   const bucket = 'foo'
-  const cid = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
+  const cid = nanoid()
   const origins = ['/p2p/12D3KooWCVU8Hjzky8u6earCs4z6m9SbznMn646Q9xt8QsvMXkgS']
   const res = await addPin({ cid, origins, bucket: 'foo', dynamo, table, sqs, queueUrl })
 
   t.is(res.cid, cid)
   t.is(res.origins[0], origins[0])
   t.is(res.type, 'pin')
-  const msgs = await sqs.send(new ReceiveMessageCommand({ QueueUrl: queueUrl, WaitTimeSeconds: 0 }))
-  const msg = JSON.parse(msgs.Messages[0].Body)
+  const msgs = await getMessagesFromSQS({ queueUrl, length: 2, sqs })
+  t.is(msgs.length, 1)
+  const msg = JSON.parse(msgs[0].Body)
   t.is(msg.cid, cid)
   t.is(msg.origins[0], origins[0])
   t.is(msg.bucket, bucket)
   t.is(msg.key, `pickup/${cid}/${cid}.root.car`)
+})
+
+test('addPin for a failed item', async t => {
+  const { dynamo, table, sqs, createQueue } = t.context
+  const queueUrl = await createQueue()
+  const bucket = 'foo'
+  const cid = nanoid()
+  const origins = ['/p2p/12D3KooWCVU8Hjzky8u6earCs4z6m9SbznMn646Q9xt8QsvMXkgS']
+
+  await putIfNotExists({ cid, dynamo, table })
+  const client = DynamoDBDocumentClient.from(dynamo)
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { cid },
+    ExpressionAttributeNames: {
+      '#status': 'status'
+    },
+    ExpressionAttributeValues: {
+      ':s': 'failed'
+    },
+    UpdateExpression: 'set #status = :s',
+    ReturnValues: 'ALL_NEW'
+  }))
+
+  const res = await addPin({ cid, origins, bucket: 'foo', dynamo, table, sqs, queueUrl })
+
+  t.is(res.cid, cid)
+  t.is(res.origins[0], origins[0])
+  t.is(res.type, 'pin')
+  const msgs = await getMessagesFromSQS({ queueUrl, length: 2, sqs })
+  t.is(msgs.length, 1)
+  const msg = JSON.parse(msgs[0].Body)
+  t.is(msg.cid, cid)
+  t.is(msg.origins[0], origins[0])
+  t.is(msg.bucket, bucket)
+  t.is(msg.key, `pickup/${cid}/${cid}.root.car`)
+})
+
+test('addPin for an item already queued', async t => {
+  const { dynamo, table, sqs, createQueue } = t.context
+  const queueUrl = await createQueue()
+  const cid = nanoid()
+  const origins = ['/p2p/12D3KooWCVU8Hjzky8u6earCs4z6m9SbznMn646Q9xt8QsvMXkgS']
+
+  const res1 = await addPin({ cid, origins, bucket: 'foo', dynamo, table, sqs, queueUrl })
+  const res2 = await addPin({ cid, origins, bucket: 'foo', dynamo, table, sqs, queueUrl })
+
+  t.is(res1.cid, cid)
+  t.is(res1.origins[0], origins[0])
+  t.is(res1.type, 'pin')
+
+  t.is(res2.cid, res1.cid)
+  t.deepEqual(res2.origins, res1.origins)
+  t.is(res2.type, res1.type)
+
+  const msgs = await getMessagesFromSQS({ queueUrl, length: 2, sqs })
+  t.is(msgs.length, 1)
+})
+
+test('addPin for an item already pinned', async t => {
+  const { dynamo, table, sqs, createQueue } = t.context
+  const queueUrl = await createQueue()
+  const cid = nanoid()
+  const origins = ['/p2p/12D3KooWCVU8Hjzky8u6earCs4z6m9SbznMn646Q9xt8QsvMXkgS']
+
+  await putIfNotExists({ cid, dynamo, table })
+  const client = DynamoDBDocumentClient.from(dynamo)
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { cid },
+    ExpressionAttributeNames: {
+      '#status': 'status'
+    },
+    ExpressionAttributeValues: {
+      ':s': 'pinned'
+    },
+    UpdateExpression: 'set #status = :s',
+    ReturnValues: 'ALL_NEW'
+  }))
+
+  const res1 = await addPin({ cid, origins, bucket: 'foo', dynamo, table, sqs, queueUrl })
+
+  t.is(res1.cid, cid)
+  t.is(res1.origins[0], origins[0])
+  t.is(res1.type, 'pin')
+
+  const msgs = await getMessagesFromSQS({ queueUrl, length: 2, sqs })
+  t.is(msgs, undefined)
 })
 
 test('putIfNotExists', async t => {
@@ -162,4 +251,14 @@ export async function createQueue (sqsPort, sqs) {
   }))
   const { QueueUrl } = await sqs.send(new GetQueueUrlCommand({ QueueName }))
   return QueueUrl.replace('9324', sqsPort)
+}
+
+export async function getMessagesFromSQS ({ queueUrl, length, sqs }) {
+  const result = await sqs.send(new ReceiveMessageCommand({
+    QueueUrl: queueUrl,
+    MaxNumberOfMessages: length,
+    WaitTimeSeconds: 1
+  }))
+
+  return result.Messages
 }

--- a/api/test/basic.test.js
+++ b/api/test/basic.test.js
@@ -63,8 +63,8 @@ test('getPin', async t => {
 
   const res3 = await getPin({ cid, dynamo, table })
   t.is(res3.cid, cid)
-  t.is(res3.status, res2.status)
-  t.is(res3.created, res2.created)
+  t.is(res3.status, res2.pin.status)
+  t.is(res3.created, res2.pin.created)
 })
 
 test('addPin', async t => {
@@ -90,18 +90,20 @@ test('putIfNotExists', async t => {
   const cid = 'bar'
   const { dynamo, table } = t.context
   const res1 = await putIfNotExists({ cid, dynamo, table })
-  t.is(res1.cid, cid)
-  t.is(res1.status, 'queued')
+  t.is(res1.shouldQueue, true)
+  t.is(res1.pin.cid, cid)
+  t.is(res1.pin.status, 'queued')
 
   const res2 = await getPin({ cid, dynamo, table })
   t.is(res2.cid, cid)
   t.is(res2.status, 'queued')
-  t.is(res2.created, res1.created)
+  t.is(res2.created, res1.pin.created)
 
   const res3 = await putIfNotExists({ cid, dynamo, table })
-  t.is(res3.cid, cid)
-  t.is(res3.status, 'queued')
-  t.is(res3.created, res1.created)
+  t.is(res3.shouldQueue, true)
+  t.is(res3.pin.cid, cid)
+  t.is(res3.pin.status, 'queued')
+  t.is(res3.pin.created, res1.pin.created)
 })
 
 test('getPin basic auth', async t => {
@@ -163,8 +165,8 @@ test('updatePinStatus', async t => {
 
   const res3 = await getPin({ cid, dynamo, table })
   t.is(res3.cid, cid)
-  t.is(res3.status, res2.status)
-  t.is(res3.created, res2.created)
+  t.is(res3.status, res2.pin.status)
+  t.is(res3.created, res2.pin.created)
 
   const s3Event = {
     Records: [{
@@ -181,7 +183,7 @@ test('updatePinStatus', async t => {
   const [res4] = JSON.parse(res.body)
   t.is(res4.cid, cid)
   t.is(res4.status, 'pinned')
-  t.is(res4.created, res2.created)
+  t.is(res4.created, res2.pin.created)
 })
 
 export async function createQueue (sqsPort, sqs) {

--- a/api/test/get-pin.test.js
+++ b/api/test/get-pin.test.js
@@ -1,6 +1,6 @@
 import { DynamoDBClient, CreateTableCommand } from '@aws-sdk/client-dynamodb'
 import { GenericContainer as Container } from 'testcontainers'
-import { putIfNotExists } from '../basic/add-pin.js'
+import { upsertOnDynamo } from '../basic/add-pin.js'
 import { getPin, handler as getPinHandler } from '../basic/get-pin.js'
 import { nanoid } from 'nanoid'
 import test from 'ava'
@@ -48,7 +48,7 @@ test('getPin', async t => {
   const res1 = await getPin({ cid, dynamo, table })
   t.is(res1, undefined)
 
-  const res2 = await putIfNotExists({ cid, dynamo, table })
+  const res2 = await upsertOnDynamo({ cid, dynamo, table })
 
   const res3 = await getPin({ cid, dynamo, table })
   t.is(res3.cid, cid)

--- a/api/test/get-pin.test.js
+++ b/api/test/get-pin.test.js
@@ -1,0 +1,79 @@
+import { DynamoDBClient, CreateTableCommand } from '@aws-sdk/client-dynamodb'
+import { GenericContainer as Container } from 'testcontainers'
+import { putIfNotExists } from '../basic/add-pin.js'
+import { getPin, handler as getPinHandler } from '../basic/get-pin.js'
+import { nanoid } from 'nanoid'
+import test from 'ava'
+
+test.before(async t => {
+  t.timeout(1000 * 60)
+
+  process.env.LOG_LEVEL = 'silent'
+
+  const dbContainer = await new Container('amazon/dynamodb-local:latest')
+    .withExposedPorts(8000)
+    .start()
+  const table = nanoid()
+  const dbEndpoint = `http://${dbContainer.getHost()}:${dbContainer.getMappedPort(8000)}`
+  const dynamo = new DynamoDBClient({
+    endpoint: dbEndpoint
+  })
+  await dynamo.send(new CreateTableCommand({
+    TableName: table,
+    AttributeDefinitions: [
+      { AttributeName: 'cid', AttributeType: 'S' }
+    ],
+    KeySchema: [
+      { AttributeName: 'cid', KeyType: 'HASH' }
+    ],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 1,
+      WriteCapacityUnits: 1
+    }
+  }))
+
+  t.context.containers = [dbContainer]
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamo = dynamo
+  t.context.table = table
+
+  t.context.lambdaContext = {
+    awsRequestId: 123123
+  }
+})
+
+test('getPin', async t => {
+  const cid = 'foo'
+  const { dynamo, table } = t.context
+  const res1 = await getPin({ cid, dynamo, table })
+  t.is(res1, undefined)
+
+  const res2 = await putIfNotExists({ cid, dynamo, table })
+
+  const res3 = await getPin({ cid, dynamo, table })
+  t.is(res3.cid, cid)
+  t.is(res3.status, res2.pin.status)
+  t.is(res3.created, res2.pin.created)
+})
+
+test('getPin basic auth', async t => {
+  process.env.CLUSTER_BASIC_AUTH_TOKEN = 'YES'
+  process.env.DYNAMO_DB_ENDPOINT = t.context.dbEndpoint
+  process.env.TABLE_NAME = t.context.table
+  const event = {
+    headers: {
+      authorization: 'nope'
+    },
+    pathParameters: {
+      cid: 'bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354'
+    }
+  }
+  const unauth = await getPinHandler(event, t.context.lambdaContext)
+  t.is(unauth.statusCode, 401)
+  t.true(typeof unauth.body === 'string')
+  t.deepEqual(JSON.parse(unauth.body), { error: { reason: 'UNAUTHORIZED' } })
+
+  event.headers.authorization = `Basic ${process.env.CLUSTER_BASIC_AUTH_TOKEN}`
+  const auth = await getPinHandler(event, t.context.lambdaContext)
+  t.is(auth.statusCode, 200)
+})

--- a/api/test/update-pin.test.js
+++ b/api/test/update-pin.test.js
@@ -1,6 +1,6 @@
 import { DynamoDBClient, CreateTableCommand } from '@aws-sdk/client-dynamodb'
 import { GenericContainer as Container } from 'testcontainers'
-import { putIfNotExists } from '../basic/add-pin.js'
+import { upsertOnDynamo } from '../basic/add-pin.js'
 import { getPin } from '../basic/get-pin.js'
 import { s3EventHandler as updatePin } from '../basic/update-pin.js'
 import { nanoid } from 'nanoid'
@@ -51,7 +51,7 @@ test('updatePinStatus', async t => {
   const res1 = await getPin({ cid, dynamo, table })
   t.is(res1, undefined)
 
-  const res2 = await putIfNotExists({ cid, dynamo, table })
+  const res2 = await upsertOnDynamo({ cid, dynamo, table })
 
   const res3 = await getPin({ cid, dynamo, table })
   t.is(res3.cid, cid)

--- a/api/test/update-pin.test.js
+++ b/api/test/update-pin.test.js
@@ -1,0 +1,77 @@
+import { DynamoDBClient, CreateTableCommand } from '@aws-sdk/client-dynamodb'
+import { GenericContainer as Container } from 'testcontainers'
+import { putIfNotExists } from '../basic/add-pin.js'
+import { getPin } from '../basic/get-pin.js'
+import { s3EventHandler as updatePin } from '../basic/update-pin.js'
+import { nanoid } from 'nanoid'
+import test from 'ava'
+
+test.before(async t => {
+  t.timeout(1000 * 60)
+
+  process.env.LOG_LEVEL = 'silent'
+
+  const dbContainer = await new Container('amazon/dynamodb-local:latest')
+    .withExposedPorts(8000)
+    .start()
+  const table = nanoid()
+  const dbEndpoint = `http://${dbContainer.getHost()}:${dbContainer.getMappedPort(8000)}`
+  const dynamo = new DynamoDBClient({
+    endpoint: dbEndpoint
+  })
+  await dynamo.send(new CreateTableCommand({
+    TableName: table,
+    AttributeDefinitions: [
+      { AttributeName: 'cid', AttributeType: 'S' }
+    ],
+    KeySchema: [
+      { AttributeName: 'cid', KeyType: 'HASH' }
+    ],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 1,
+      WriteCapacityUnits: 1
+    }
+  }))
+
+  t.context.containers = [dbContainer]
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamo = dynamo
+  t.context.table = table
+
+  t.context.lambdaContext = {
+    awsRequestId: 123123
+  }
+})
+
+test('updatePinStatus', async t => {
+  process.env.DYNAMO_DB_ENDPOINT = t.context.dbEndpoint
+  process.env.TABLE_NAME = t.context.table
+  const cid = 'update'
+  const { dynamo, table } = t.context
+  const res1 = await getPin({ cid, dynamo, table })
+  t.is(res1, undefined)
+
+  const res2 = await putIfNotExists({ cid, dynamo, table })
+
+  const res3 = await getPin({ cid, dynamo, table })
+  t.is(res3.cid, cid)
+  t.is(res3.status, res2.pin.status)
+  t.is(res3.created, res2.pin.created)
+
+  const s3Event = {
+    Records: [{
+      eventName: 'ObjectCreated:Put',
+      s3: {
+        object: {
+          key: `pickup/${cid}.car`
+        }
+      }
+    }]
+  }
+
+  const res = await updatePin(s3Event, t.context.lambdaContext)
+  const [res4] = JSON.parse(res.body)
+  t.is(res4.cid, cid)
+  t.is(res4.status, 'pinned')
+  t.is(res4.created, res2.pin.created)
+})


### PR DESCRIPTION
in this PR:
* update the state of the dynamo entry to `queued` when the state in dynamoDB is `failed`
* test refactoring for the add/get/update endpoint
* skip enqueue when adding a pin that's already `pinned` or `queued`
