### PR TITLE
chore: update to kubo v0.18.1

### DIFF
--- a/pickup/ipfs/Dockerfile
+++ b/pickup/ipfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipfs/kubo:v0.16.0
+FROM ipfs/kubo:v0.18.1
 
 ADD ipfs-config.sh /container-init.d/ipfs-config.sh
 RUN chmod a+x /container-init.d/ipfs-config.sh


### PR DESCRIPTION
Gonna hold this one until we have a baseline of metrics for pickup so we can see the impact if any, given this one introduces libp2p resource management.

Depends on https://github.com/web3-storage/web3.storage/pull/2216 to get a baseline metric in place first.

License: MIT