### PR TITLE
fix: retry failed fetches

### DIFF
--- a/api/basic/helper/fetchers.ts
+++ b/api/basic/helper/fetchers.ts
@@ -1,5 +1,5 @@
 import * as querystring from 'node:querystring'
-import fetch, { RequestInit } from 'node-fetch'
+import fetch, { RequestInit, Response } from 'node-fetch'
 import retry from 'p-retry'
 
 import { ClusterAddResponseBody, ClusterGetResponseBody } from '../schema.js'
@@ -30,8 +30,8 @@ export interface FetchGetPinsParams {
 /**
  * Retry if fetch throws or there was a server-side error
  */
-function fetchWithRetry (url: URL, init?: RequestInit) {
-  async function fetchAndCheckStatus (url: URL, init?: RequestInit) {
+async function fetchWithRetry (url: URL, init?: RequestInit): Promise<Response> {
+  async function fetchAndCheckStatus (url: URL, init?: RequestInit): Promise<Response> {
     const res = await fetch(url.href, init)
     if (res.status >= 500) {
       throw new Error(res.statusText)
@@ -39,7 +39,7 @@ function fetchWithRetry (url: URL, init?: RequestInit) {
     return res
   }
 
-  return retry(() => fetchAndCheckStatus(url, init), {
+  return await retry(async () => await fetchAndCheckStatus(url, init), {
     retries: 5,
     randomize: true,
     onFailedAttempt: ({ attemptNumber, retriesLeft, message }) => logger.debug({ code: 'FETCH_RETRY', url, attemptNumber, retriesLeft }, `Fetch failed: ${message}`)

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "nanoid": "^4.0.0",
     "node-fetch": "^3.3.0",
     "openapi-backend": "^5.3.0",
+    "p-retry": "^5.1.2",
     "pino-lambda": "4.1.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "nanoid": "^4.0.0",
         "node-fetch": "^3.3.0",
         "openapi-backend": "^5.3.0",
+        "p-retry": "^5.1.2",
         "pino-lambda": "4.1.0"
       },
       "devDependencies": {
@@ -7222,6 +7223,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -14690,6 +14696,21 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -24453,6 +24474,11 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
     "@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -29923,6 +29949,15 @@
         "aggregate-error": "^4.0.0"
       }
     },
+    "p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "requires": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      }
+    },
     "p-timeout": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
@@ -30061,6 +30096,7 @@
         "nanoid": "^4.0.0",
         "node-fetch": "^3.3.0",
         "openapi-backend": "^5.3.0",
+        "p-retry": "*",
         "pino-lambda": "4.1.0"
       },
       "dependencies": {


### PR DESCRIPTION
Make things robust to temporary errors like "that cluster node you tried is refusing connections" by retrying failed fetches

in prod pin requests are failing even though we are passing 100 of the traffic through to cluster because we keep hitting a cluster node that is refusing connections, when checking to see if we already have the CID for a new pin request

https://github.com/web3-storage/pickup/blob/main/api/basic/add-pin-router.ts#L125

see: https://github.com/web3-storage/web3.storage/issues/2217

License: MIT