### PR TITLE
fix: handle startup errors

### DIFF
--- a/pickup/index.js
+++ b/pickup/index.js
@@ -9,7 +9,7 @@ async function start () {
     logger.info('Pickup started')
   } catch (err) {
     logger.error(err, 'Pickup ded!')
-    throw err
+    process.exit(1)
   }
 }
 

--- a/pickup/lib/ipfs.js
+++ b/pickup/lib/ipfs.js
@@ -198,7 +198,7 @@ export class CarFetcher {
   }
 
   async testIpfsApi () {
-    return retry(() => testIpfsApi(this.ipfsApiUrl), { retries: 4 })
+    return retry(() => testIpfsApi(this.ipfsApiUrl), { retries: 10 })
   }
 
   /**

--- a/pickup/lib/pickup.js
+++ b/pickup/lib/pickup.js
@@ -92,9 +92,14 @@ export function createPickup ({ sqsPoller, carFetcher, s3Uploader }) {
 
   const pollerStart = sqsPoller.start.bind(sqsPoller)
   sqsPoller.start = async () => {
-    // throw if we can't connect to kubo
-    await carFetcher.testIpfsApi()
-    return pollerStart()
+    try {
+      // throw if we can't connect to kubo
+      await carFetcher.testIpfsApi()
+      return pollerStart()
+    } catch (err) {
+      logger.error({ err, ipfsApiUrl: carFetcher.ipfsApiUrl }, 'Failed to connect to ipfs api')
+      throw new Error('Failed to connect to ipfs api')
+    }
   }
 
   return sqsPoller


### PR DESCRIPTION
throwing and uncaught error leaves us with a multi log line stacktace where all our other log lines are json encoded / pino format. The mix makes querying the log messy.

fixed here to wait longer for ipfs to be ready by retrying more, and to log the error and quit rather than explode.

License: MIT