### PR TITLE
feat: calculate car cid and size during validation

### DIFF
--- a/pickup/lib/car.js
+++ b/pickup/lib/car.js
@@ -1,5 +1,12 @@
+import crypto from 'node:crypto'
+import { concat } from 'node:stream'
 import { CarBlockIterator } from '@ipld/car'
 import { LinkIndexer } from 'linkdex'
+import * as Link from 'multiformats/link'
+import * as Digest from 'multiformats/hashes/digest'
+import { sha256 } from 'multiformats/hashes/sha2'
+
+const CAR_CODEC = 0x0202
 
 /**
  * @param {AsyncIterable<Uint8Array>} car
@@ -14,4 +21,37 @@ export async function linkdex (car) {
   }
 
   return linkIndexer.report()
+}
+
+/**
+ * A pass through stream that updates the hash digest
+ * @param {import('node:crypto').Hash} hash
+ */
+export function createHashStream (hash) {
+  return async function * passThruHash (source) {
+    for await (const chunk of source) {
+      hash.update(chunk)
+      yield chunk
+    }
+  }
+}
+
+/**
+ * @param {import('node:crypto').Hash} hash
+ */
+export function createCarCid (hash) {
+  const digest = Digest.create(sha256.code, hash.digest())
+  return Link.create(CAR_CODEC, digest)
+}
+
+/**
+ * Stream a car through linkdex to check if it's complete, and create the carCid
+ *
+ * @param {AsyncIterable<Uint8Array>} car
+ */
+export async function checkCar (car) {
+  const sha256 = crypto.createHash('sha256')
+  const report = await linkdex(concat(car, createHashStream(sha256)))
+  const carCid = createCarCid(sha256)
+  return { carCid, report }
 }

--- a/pickup/lib/pickup.js
+++ b/pickup/lib/pickup.js
@@ -74,8 +74,8 @@ export function createPickup ({ sqsPoller, carFetcher, s3Uploader, pinTable }) {
       logger.info({ cid, origins }, 'Fetching CAR')
       await carFetcher.connectTo(origins)
       const body = await carFetcher.fetch({ cid, origins, abortCtl })
-      await upload(body)
-      logger.info({ cid, origins }, 'OK. Car in S3')
+      const { carCid, carSize } = await upload(body)
+      logger.info({ cid, origins, carCid, carSize }, 'OK. Car in S3')
       await msg.del() // the message is handled, remove it from queue.
     } catch (err) {
       if (abortCtl.signal.reason === TOO_BIG) {

--- a/pickup/lib/s3.js
+++ b/pickup/lib/s3.js
@@ -43,7 +43,7 @@ export async function uploadAndVerify ({ client, validationBucket, destinationBu
     throw new Error('checkCar failed', { cause: err })
   }
 
-  const { carCid, carBytes, report } = check
+  const { carCid, carSize, report } = check
 
   if (report.blocksIndexed === 0) {
     logger.info({ report, cid }, 'linkdex: Empty CAR')
@@ -61,7 +61,7 @@ export async function uploadAndVerify ({ client, validationBucket, destinationBu
     Key: `${carCid}/${carCid}.car`
   })), { retries: 5, onFailedAttempt: (err) => logger.info({ err, cid }, 'Copy to destination failed, retrying') })
 
-  return { carCid, carBytes, cid }
+  return { carCid, carSize, cid }
 }
 
 export class S3Uploader {

--- a/pickup/test/car.test.js
+++ b/pickup/test/car.test.js
@@ -1,0 +1,14 @@
+import { packToBlob } from 'ipfs-car/pack/blob'
+import { checkCar } from '../lib/car.js'
+import test from 'ava'
+
+test('checkCar', async t => {
+  const { car } = await packToBlob({ input: 'hello world', wrapWithDirectory: false })
+  const { carCid, carBytes, report } = await checkCar(car.stream())
+  t.is(carCid.toString(), 'bagbaierao5e6fdcp4p3iyafmbcxudqoe63qcoxegxwpivz5zirw2pulgg4ia')
+  t.is(report.blocksIndexed, 1)
+  t.is(report.undecodeable, 0)
+  t.is(report.uniqueCids, 1)
+  t.is(report.structure, 'Complete')
+  t.is(carBytes, 107)
+})

--- a/pickup/test/car.test.js
+++ b/pickup/test/car.test.js
@@ -4,11 +4,11 @@ import test from 'ava'
 
 test('checkCar', async t => {
   const { car } = await packToBlob({ input: 'hello world', wrapWithDirectory: false })
-  const { carCid, carBytes, report } = await checkCar(car.stream())
+  const { carCid, carSize, report } = await checkCar(car.stream())
   t.is(carCid.toString(), 'bagbaierao5e6fdcp4p3iyafmbcxudqoe63qcoxegxwpivz5zirw2pulgg4ia')
   t.is(report.blocksIndexed, 1)
   t.is(report.undecodeable, 0)
   t.is(report.uniqueCids, 1)
   t.is(report.structure, 'Complete')
-  t.is(carBytes, 107)
+  t.is(carSize, 107)
 })


### PR DESCRIPTION
Update car key to `${carCid}/${carCid}.car`, so we can start writing them to carpark.

Calculate the sha256 of the car bytes from the stream as we produce the linkdex report to determine if the car is complete / valid

Log total bytes per CAR as `carSize`. Use this to calculate the throughput in loki. Needed as we wont be able to use the size of the bucket once we start writing to the shared carpark.

Fixes https://github.com/web3-storage/pickup/issues/136

TODO
- [ ] update the production and staging env to write to carpark bucket.

License: MIT