### PR TITLE
fix: update validation bucket lifecycle rules to auto delete

### DIFF
--- a/stacks/PickupStack.ts
+++ b/stacks/PickupStack.ts
@@ -16,7 +16,14 @@ export function PickupStack ({ app, stack }: StackContext): void {
     cdk: {
       bucket: {
         lifecycleRules: [
-          { expiration: Duration.days(1) } // minimum is 1 day
+          {
+            expiration: Duration.days(1), // minimum is 1 day
+            noncurrentVersionExpiration: Duration.days(1),
+            abortIncompleteMultipartUploadAfter: Duration.days(1)
+          },
+          {
+            expiredObjectDeleteMarker: true
+          }
         ]
       }
     }


### PR DESCRIPTION
the validation bucket is filling up. it was supposed to be auto deleting things every 24hrs.

update the lifecycle rules, translated from the guide in https://repost.aws/knowledge-center/s3-empty-bucket-lifecycle-rule

License: MIT