### PR TITLE
feat: write to carpark

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -7,12 +7,9 @@ CLUSTER_BASIC_AUTH_TOKEN="???"
 # Indexer base url (The example below is referred to staging)
 LEGACY_CLUSTER_IPFS_URL="https://nft.storage.ipfscluster.io/api"
 
-# Indexer base url
-# 0 -> all request to Indexer
-# 100 -> All request to Pickup
-# values in between the balancer is applied (eg. 15 -> 15% of the request to Pickup, 85% to Indexer)
-BALANCER_RATE=10
+# Optional - name of bucket to write CARs to. Default: `carpark-staging-0`
+# CARPARK="my-bucket-name"
 
-# uncomment to try out deploying the api under a custom domain.
+# Optional - deploying the api under a custom domain.
 # the value should match a hosted zone configured in route53 that your aws account has access to.
 # HOSTED_ZONE=pickup.dag.haus

--- a/pickup/lib/dynamo.js
+++ b/pickup/lib/dynamo.js
@@ -47,4 +47,27 @@ export class PinTable {
     const res = await this.dynamo.send(cmd)
     return res.Item
   }
+
+  /**
+   * Update the pin status for a given CID
+   *
+   * @param {object} config
+   * @param {string} config.cid
+   * @param {string} [config.status]
+   */
+  async updatePinStatus (cid, status = 'pinned') {
+    const res = await this.dynamo.send(new UpdateCommand({
+      TableName: this.table,
+      Key: { cid },
+      ExpressionAttributeNames: {
+        '#status': 'status'
+      },
+      ExpressionAttributeValues: {
+        ':s': status
+      },
+      UpdateExpression: 'set #status = :s',
+      ReturnValues: 'ALL_NEW'
+    }))
+    return res.Attributes
+  }
 }

--- a/pickup/lib/pickup.js
+++ b/pickup/lib/pickup.js
@@ -76,6 +76,7 @@ export function createPickup ({ sqsPoller, carFetcher, s3Uploader, pinTable }) {
       const body = await carFetcher.fetch({ cid, origins, abortCtl })
       await upload(body)
       logger.info({ cid, origins }, 'OK. Car in S3')
+      await pinTable.updatePinStatus({ cid })
       await msg.del() // the message is handled, remove it from queue.
     } catch (err) {
       if (abortCtl.signal.reason === TOO_BIG) {

--- a/stacks/BasicApiStack.ts
+++ b/stacks/BasicApiStack.ts
@@ -56,7 +56,7 @@ export function BasicApiStack ({
 
   const bucket = new Bucket(stack, 'Car', {
     cdk: {
-      bucket: s3.Bucket.fromBucketArn(stack, 'carpark', process.env.CARPARK_ARN)
+      bucket: s3.Bucket.fromBucketName(stack, 'carpark', process.env.CARPARK ?? 'carpark-staging-0')
     }
   })
 


### PR DESCRIPTION
Write to the existing carpark bucket rather than creating a dedicated one for pickup.

Updater the pin status on successful write to s3 from the pickup worker. Previously we'd listen for object_created events and trigger a lambda to update the pin status, but we're moving to a shared bucket, so handle it in the worker.

Part of #136 