### PR TITLE
fix: only auto-destroy stateful resources on PR builds

### DIFF
--- a/stacks/index.ts
+++ b/stacks/index.ts
@@ -1,10 +1,10 @@
 import { Tags, RemovalPolicy } from 'aws-cdk-lib'
-import { PickupStack } from './PickupStack'
+import { PickupStack, isPrBuild } from './PickupStack'
 import { BasicApiStack } from './BasicApiStack'
 import { App } from '@serverless-stack/resources'
 
 export default function (app: App): void {
-  if (!(app.stage in ['prod', 'staging'])) {
+  if (isPrBuild(app)) {
     app.setDefaultRemovalPolicy(RemovalPolicy.DESTROY)
   }
 


### PR DESCRIPTION
we're deploying a previous change that makes the old prod bucket redundant.

the deploy failed as cloudformation tried to delete the prod bucket(!) but found it had objects in, so the deploy failed instead.

License: MIT